### PR TITLE
Update docker containers for postgres fuzzing

### DIFF
--- a/Containers/Crusher/Linux/Postgres/Dockerfile.DRIO.txt
+++ b/Containers/Crusher/Linux/Postgres/Dockerfile.DRIO.txt
@@ -42,4 +42,4 @@ RUN /usr/lib/postgresql/12/bin/initdb -D /home/$cuidname/data
 USER root
 ENV cuidname=$cuidname
 ENV cgidname=$cgidname
-CMD echo $cuidname && chown -R $cuidname:$cgidname /home/$cuidname/out && sudo -u $cuidname ./crusher/bin_x86-64/fuzz_manager -i in/ -o out/ -F -T stdin -t 1000 -m 10000 --no-inst-libs --start 1 --session $FUZZ_INSTANCE --eat-cores 0 --dse-cores 0 --dse-threads 0 -- /usr/lib/postgresql/12/bin/postgres --single -D /home/$cuidname/data postgres
+CMD echo $cuidname && chown -R $cuidname:$cgidname /home/$cuidname/out && sudo -u $cuidname ./crusher/bin_x86-64/fuzz_manager -i in/ -o out/ -F -T stdin -t 3000 -m 10000 --no-inst-libs --start 1 --session $FUZZ_INSTANCE --eat-cores 0 --dse-cores 0 --dse-threads 0 -- /usr/lib/postgresql/12/bin/postgres --single -D /home/$cuidname/data postgres

--- a/Containers/Crusher/Linux/Postgres/Dockerfile.EAT.txt
+++ b/Containers/Crusher/Linux/Postgres/Dockerfile.EAT.txt
@@ -9,12 +9,12 @@ ARG cuidname=crusher
 ARG cgidname=crusher
 
 #Just a notes
-LABEL maintainer="ponomarev@sinclit.ru"
+LABEL maintainer="ponomarev@fobos-nt.ru"
 LABEL version="1.0"
 LABEL description="Boilerplate for crusher EAT work"
 
 #Install system packages
-RUN apt update && apt install -y gcc clang llvm make sudo git
+RUN apt update && apt install -y gcc clang llvm make sudo git wget
 
 #Add group and user (like my HOST group and user)
 RUN groupadd -g $cgid $cgidname &&  useradd -m -u $cuid -g $cgidname -G sudo -s /usr/bin/bash $cuidname
@@ -24,9 +24,10 @@ ADD crusher.tar.gz /home/$cuidname
 
 #Compile afl++ compilers
 WORKDIR /home/$cuidname
-RUN git clone https://github.com/AFLplusplus/AFLplusplus
-WORKDIR /home/$cuidname/AFLplusplus
-RUN make
+RUN wget https://github.com/AFLplusplus/AFLplusplus/archive/3.0c.tar.gz \
+    && tar xvf 3.0c.tar.gz
+WORKDIR /home/$cuidname/AFLplusplus-3.0c
+RUN make -j10
 
 #Getting inputs from HOST
 WORKDIR /home/$cuidname
@@ -44,7 +45,7 @@ RUN git clone --single-branch --branch REL_12_STABLE --depth 1 https://github.co
 WORKDIR /home/$cuidname/postgres
 
 #Configuring and compiling the Target for fuzzing
-RUN CC=/home/$cuidname/AFLplusplus/afl-clang-lto CXX=/home/$cuidname/AFLplusplus/afl-clang-lto++  AFL_USE_UBSAN=1 AFL_LLVM_LAF_ALL=1 ./configure --prefix /home/$cuidname/pgbuild
+RUN CC=/home/$cuidname/AFLplusplus-3.0c/afl-clang-fast CXX=/home/$cuidname/AFLplusplus-3.0c/afl-clang-fast++ AFL_USE_UBSAN=1 AFL_LLVM_LAF_ALL=1 ./configure --prefix /home/$cuidname/pgbuild
 RUN make -j10 && make install
 WORKDIR /home/$cuidname/
 
@@ -56,4 +57,4 @@ RUN /home/$cuidname/pgbuild/bin/initdb -D /home/$cuidname/data
 USER root
 ENV cuidname=$cuidname
 ENV cgidname=$cgidname
-CMD echo core >/proc/sys/kernel/core_pattern && chown -R $cuidname:$cgidname /home/$cuidname/out && sudo -u $cuidname ./crusher/bin_x86-64/eat -o out/ -F -I StaticForkSrv -T stdin -t 1000 -- /home/$cuidname/pgbuild/bin/postgres --single -D /home/$cuidname/data postgres
+CMD echo core >/proc/sys/kernel/core_pattern && chown -R $cuidname:$cgidname /home/$cuidname/out && sudo -u $cuidname ./crusher/bin_x86-64/eat -o out/ -F -I StaticForkSrv --bitmap-size 150000 -T stdin -t 3000 -- /home/$cuidname/pgbuild/bin/postgres --single -D /home/$cuidname/data postgres

--- a/Containers/Crusher/Linux/Postgres/Dockerfile.STATIC.txt
+++ b/Containers/Crusher/Linux/Postgres/Dockerfile.STATIC.txt
@@ -14,7 +14,7 @@ LABEL version="1.0"
 LABEL description="Boilerplate for crusher work in stat inst mode"
 
 #Install system packages
-RUN apt update && apt install -y gcc clang llvm make sudo git
+RUN apt update && apt install -y gcc clang llvm make sudo git wget
 
 #Add group and user (like my HOST group and user)
 RUN groupadd -g $cgid $cgidname &&  useradd -m -u $cuid -g $cgidname -G sudo -s /usr/bin/bash $cuidname
@@ -24,9 +24,10 @@ ADD crusher.tar.gz /home/$cuidname
 
 #Compile afl++ compilers
 WORKDIR /home/$cuidname
-RUN git clone https://github.com/AFLplusplus/AFLplusplus
-WORKDIR /home/$cuidname/AFLplusplus
-RUN make
+RUN wget https://github.com/AFLplusplus/AFLplusplus/archive/3.0c.tar.gz \
+    && tar xvf 3.0c.tar.gz
+WORKDIR /home/$cuidname/AFLplusplus-3.0c
+RUN make -j10
 
 #Getting inputs from HOST
 WORKDIR /home/$cuidname
@@ -44,7 +45,7 @@ RUN git clone --single-branch --branch REL_12_STABLE --depth 1 https://github.co
 WORKDIR /home/$cuidname/postgres
 
 #Configuring and compiling the Target for fuzzing
-RUN CC=/home/$cuidname/AFLplusplus/afl-clang-fast CXX=/home/$cuidname/AFLplusplus/afl-clang-fast++ AFL_USE_UBSAN=1 AFL_LLVM_LAF_ALL=1 ./configure --prefix /home/$cuidname/pgbuild
+RUN CC=/home/$cuidname/AFLplusplus-3.0c/afl-clang-fast CXX=/home/$cuidname/AFLplusplus-3.0c/afl-clang-fast++ AFL_USE_UBSAN=1 AFL_LLVM_LAF_ALL=1 ./configure --prefix /home/$cuidname/pgbuild
 RUN make -j10 && make install
 WORKDIR /home/$cuidname/
 
@@ -56,4 +57,6 @@ RUN /home/$cuidname/pgbuild/bin/initdb -D /home/$cuidname/data
 USER root
 ENV cuidname=$cuidname
 ENV cgidname=$cgidname
-CMD echo core >/proc/sys/kernel/core_pattern && chown -R $cuidname:$cgidname /home/$cuidname/out && sudo -u $cuidname ./crusher/bin_x86-64/fuzz_manager -i in/ -o out/ -F -I StaticForkSrv -T stdin -t 1000 -m 10000 --start 1 --session $FUZZ_INSTANCE --eat-сores 0 --dse-cores 0 --dse-threads 0 -- /home/$cuidname/pgbuild/bin/postgres --single -D /home/$cuidname/data postgres
+CMD echo core >/proc/sys/kernel/core_pattern \
+    && chown -R $cuidname:$cgidname /home/$cuidname/out \
+    && sudo -u $cuidname ./crusher/bin_x86-64/fuzz_manager --start 1 --eat-cores 0 --dse-cores 0 --dse-threads 0 -i in/ -o out/ -F -I StaticForkSrv --bitmap-size 150000 -T stdin -t 3000 -m 10000 --session $FUZZ_INSTANCE -- /home/$cuidname/pgbuild/bin/postgres --single -D /home/$cuidname/data postgres


### PR DESCRIPTION
Из-за проблем с запуском фаззинга со статической инструментацией из крайних версий AFL++ зафиксировал в контейнерах версию AFL++ v3.0c